### PR TITLE
Fix single ticker data retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ This project is a Monte Carlo simulator for portfolio value predictions using hi
 ## Usage
 ```bash
 streamlit run montecarlo.py
+```

--- a/montecarlo.py
+++ b/montecarlo.py
@@ -148,6 +148,11 @@ st.sidebar.text_area("Configuration String (Copy to share)", config_string, heig
 st.write(f"Fetching historical data for {tickers}...")
 try:
     data = yf.download(tickers, start=start_date, end=end_date)['Adj Close']
+
+    # yf.download returns a Series when only one ticker is provided. Convert it
+    # to a DataFrame so downstream operations work consistently.
+    if isinstance(data, pd.Series):
+        data = data.to_frame(tickers[0])
     
     if data.empty:
         st.error("No data retrieved. Please check if the ticker symbols are correct.")


### PR DESCRIPTION
## Summary
- avoid errors when running simulations with a single ticker by converting the
  returned Series from `yf.download` into a DataFrame
- close unclosed code block in README

## Testing
- `python3 -m py_compile montecarlo.py`

------
https://chatgpt.com/codex/tasks/task_e_684011aa8d7883209d5337fe27210364