### PR TITLE
Fix data download error when Adj Close missing

### DIFF
--- a/montecarlo.py
+++ b/montecarlo.py
@@ -147,7 +147,15 @@ st.sidebar.text_area("Configuration String (Copy to share)", config_string, heig
 # Step 2: Download Historical Data with Error Handling
 st.write(f"Fetching historical data for {tickers}...")
 try:
-    data = yf.download(tickers, start=start_date, end=end_date)['Adj Close']
+    data = yf.download(tickers, start=start_date, end=end_date, group_by="column")
+
+    # yfinance may return either 'Adj Close' or only 'Close'.
+    if 'Adj Close' in data.columns:
+        data = data['Adj Close']
+    elif 'Close' in data.columns:
+        data = data['Close']
+    else:
+        raise KeyError("Neither 'Adj Close' nor 'Close' data available")
 
     # yf.download returns a Series when only one ticker is provided. Convert it
     # to a DataFrame so downstream operations work consistently.


### PR DESCRIPTION
## Summary
- handle cases where 'Adj Close' column is unavailable in yfinance data

## Testing
- `python -m py_compile montecarlo.py`

------
https://chatgpt.com/codex/tasks/task_e_684014dbab648320b979f1dad5b2b565