### PR TITLE
Add caching for historical data downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This project is a Monte Carlo simulator for portfolio value predictions using hi
 - Run simulations using custom stock tickers and weights.
 - Analyze portfolio performance with risk metrics and visualizations.
 - Export simulation results to graphs and files.
+- Historical data downloads are cached for faster reruns and automatically
+  refreshed when the tickers or date range change.
 
 ## Installation
 1. Clone this repository:


### PR DESCRIPTION
## Summary
- cache `yf.download` results with `@st.cache_data`
- automatically invalidate cache when tickers or date range change
- document caching in README

## Testing
- `python -m py_compile montecarlo.py`

------
https://chatgpt.com/codex/tasks/task_e_6840165375c88320b2ccabd97d397d14