### PR TITLE
Add CSV download option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This project is a Monte Carlo simulator for portfolio value predictions using hi
 - Run simulations using custom stock tickers and weights.
 - Analyze portfolio performance with risk metrics and visualizations.
 - Export simulation results to graphs and files.
+- Download final values and sample paths as CSV.
 
 ## Installation
 1. Clone this repository:

--- a/montecarlo.py
+++ b/montecarlo.py
@@ -258,6 +258,21 @@ try:
     st.pyplot(fig)
     plt.close()
 
+    # Allow users to download simulation results as CSV
+    st.subheader("Export Results")
+    download_df = pd.DataFrame(
+        simulation_results,
+        columns=[f"Step_{i+1}" for i in range(time_horizon)]
+    )
+    download_df.insert(0, "Final Value", final_values)
+    csv_data = download_df.to_csv(index=False)
+    st.download_button(
+        label="Download CSV",
+        data=csv_data,
+        file_name="simulation_results.csv",
+        mime="text/csv"
+    )
+
 except Exception as e:
     st.error(f"Error during simulation: {e}")
     st.stop()


### PR DESCRIPTION
## Summary
- export all simulation results to CSV
- add a "Download CSV" button in the app
- document CSV export option in README

## Testing
- `python -m py_compile montecarlo.py`


------
https://chatgpt.com/codex/tasks/task_e_6840165521f883209dd87df53e2cdc86